### PR TITLE
chore: bump projen to version 0.86.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.6
         with:
           name: .repo.patch
           path: .repo.patch

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -28,7 +28,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.6
         with:
           name: .repo.patch
           path: .repo.patch

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint-plugin-import": "^2.29.1",
     "jest": "^27",
     "jest-junit": "^15",
-    "projen": "^0.86.6",
+    "projen": "^0.86.7",
     "projen-github-action-typescript": "^0.0.433",
     "ts-jest": "^27",
     "typescript": "^4.9.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3444,10 +3444,10 @@ projen-github-action-typescript@^0.0.433:
   resolved "https://registry.yarnpkg.com/projen-github-action-typescript/-/projen-github-action-typescript-0.0.433.tgz#cefc4faad3909afa2e4d34d6a9cceeceea44ac76"
   integrity sha512-u9jcRjE1RsqnDEDP81xH3b4Z2ZF22TQruUPc271IQzZh2iM0WIKXfY9VLWtKeglxwqBEMPbhT2Q7qvcO2Vvz1w==
 
-projen@^0.86.6:
-  version "0.86.6"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.86.6.tgz#65943163283a291fedbd61c53a9c3cbd21c109dd"
-  integrity sha512-UBDdUrNku6y4fTx++YXVMi9NqaaWOUzEAzPVSVtUkOdW0itV7YfE9GxXRbVrM8gB+b3doem1o1kdddaEkfsuDw==
+projen@^0.86.7:
+  version "0.86.7"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.86.7.tgz#d6a9b4d72d8334077f482c4c9aa1c192ace94599"
+  integrity sha512-bNJVggJggmKaNGwoQ0FK1OgVbLv7Uf3hzKRkU3n5R4LhcfGoLFWvvZ9Y4fI/+FEowqhNrnukiG8Z2PhIMjuxwg==
   dependencies:
     "@iarna/toml" "^2.2.5"
     case "^1.6.3"


### PR DESCRIPTION
Fixes failing workflows. See [here](https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/) for change reason.